### PR TITLE
ci: make releases a two-phase pull-request flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,9 @@ git push -u origin fix-something
 gh pr create --fill
 ```
 
+Releases are two-phase for the same reason: `scripts/release.sh <version>` opens a PR with the
+bump and changelog, and `scripts/release.sh --tag <version>` tags it once merged.
+
 See [`VERSIONING.md`](VERSIONING.md) for what a version bump means — note that a change to the
 container bytes is breaking even when no signature changes — and
 [`docs/MAINTENANCE.md`](docs/MAINTENANCE.md) for what runs automatically.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -48,16 +48,21 @@ changelog is generated from them. Earlier history is classified by pattern in `c
 
 ## Cutting a release
 
+Two phases, because `main` is protected and takes no direct pushes:
+
 ```bash
-scripts/release.sh 0.2.0
-git push origin main --follow-tags
+scripts/release.sh 0.2.0          # verify, bump, changelog, open a PR
+# ... merge it once green ...
+git switch main && git pull
+scripts/release.sh --tag 0.2.0    # tag the merged commit, push the tag
 ```
 
-The script verifies, bumps every manifest, regenerates `CHANGELOG.md` and pauses for review
-before tagging. It refuses to tag unless the suite passes, interop included.
+Phase one refuses to proceed unless the whole suite passes, interop included, and pauses for you
+to read the generated changelog. Phase two refuses to tag unless `main` is level with the remote
+and actually carries the version being tagged.
 
-It builds and signs nothing locally: pushing the tag is the trigger. CI then builds every target,
-creates the GitHub release with the changelog section as its notes, attaches the binaries,
-checksums and SBOM, and publishes the wheels to PyPI. Provenance binding an artifact to a
-workflow run is not something a laptop can produce. See
+Branch protection does not apply to tags, so the second phase pushes directly. Tagging is the
+trigger: CI builds every target, creates the GitHub release with the changelog section as its
+notes, and attaches the binaries, wheels, checksums and SBOM. Nothing is signed locally —
+provenance binding an artifact to a workflow run is not something a laptop can produce. See
 [`docs/MAINTENANCE.md`](docs/MAINTENANCE.md).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 #
-# Prepare a release: verify, bump, regenerate the changelog, commit, tag.
+# Prepare a release. Two phases, because `main` is protected and takes no direct pushes.
 #
-#   scripts/release.sh 0.2.0
+#   scripts/release.sh 0.2.0          # verify, bump, changelog, open a PR
+#   ... merge the PR once it is green ...
+#   scripts/release.sh --tag 0.2.0    # tag the merged commit and push the tag
+#
+# Tagging is what starts the release workflow. Branch protection does not apply to tags, so the
+# second phase pushes directly.
 #
 # This script does *not* build or publish anything. Tagging is the trigger: CI builds the
 # binaries, generates the SBOM and signs everything with attestations that bind each artifact to
@@ -22,13 +27,49 @@ die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 step() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
 ok()   { printf '  \033[32mok\033[0m %s\n' "$*"; }
 
+MODE="prepare"
+if [ "${1:-}" = "--tag" ]; then MODE="tag"; shift; fi
+
 VERSION="${1:-}"
-[ -n "$VERSION" ] || die "usage: scripts/release.sh <version>   e.g. 0.2.0"
+[ -n "$VERSION" ] || die "usage: scripts/release.sh [--tag] <version>   e.g. 0.2.0"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
   || die "'$VERSION' is not a semantic version"
 
 CURRENT="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
 TAG="v$VERSION"
+BRANCH_NAME="release/$VERSION"
+
+# ---------------------------------------------------------------------------
+# Phase two: tag a version whose bump has already merged.
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "tag" ]; then
+  step "Tagging $TAG"
+
+  [ -z "$(git status --porcelain)" ] || die "working tree is not clean"
+  [ "$(git symbolic-ref --short HEAD)" = "main" ] || die "tag from main"
+  git fetch --quiet origin main
+  [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] \
+    || die "main is not level with origin/main; pull first"
+  git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists"
+
+  [ "$CURRENT" = "$VERSION" ] \
+    || die "Cargo.toml says $CURRENT, not $VERSION — has the release PR merged?"
+  ok "main is at $VERSION and level with origin"
+
+  git tag -a "$TAG" -m "umbrik $VERSION"
+  git push origin "$TAG"
+  ok "pushed $TAG"
+
+  cat <<EOF
+
+The release workflow is now running. It builds every target, generates the SBOM, signs everything
+with attestations, and creates the GitHub release with the CHANGELOG.md section as its notes.
+
+  gh run watch
+  gh release view "$TAG"
+EOF
+  exit 0
+fi
 
 # ---------------------------------------------------------------------------
 step "Preconditions"
@@ -40,6 +81,8 @@ ok "working tree clean"
 BRANCH="$(git symbolic-ref --short HEAD)"
 [ "$BRANCH" = "main" ] || die "on branch '$BRANCH'; releases are cut from main"
 ok "on main"
+
+command -v gh >/dev/null || die "gh is not installed"
 
 git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists"
 ok "tag $TAG is free"
@@ -92,30 +135,33 @@ git-cliff --tag "$TAG" --output CHANGELOG.md
 ok "CHANGELOG.md regenerated"
 
 printf '\n  \033[1mReview the changelog before continuing.\033[0m\n'
-printf '  Generated entries come from commit messages; fix anything that reads poorly now,\n'
-printf '  because it is what users will see.\n\n'
-read -r -p "  Commit and tag $TAG? [y/N] " reply
+printf '  Entries come from commit messages; fix anything that reads poorly now, because it is\n'
+printf '  what users will see.\n\n'
+read -r -p "  Open a release PR for $VERSION? [y/N] " reply
 [ "$reply" = "y" ] || [ "$reply" = "Y" ] || die "aborted; version bump left in the working tree"
 
 # ---------------------------------------------------------------------------
-step "Commit and tag"
+step "Release PR"
 # ---------------------------------------------------------------------------
 
+git switch -c "$BRANCH_NAME" --quiet
 git add -A
-git commit -q -m "Release $VERSION"
-git tag -a "$TAG" -m "umbrik $VERSION"
-ok "committed and tagged $TAG"
+git commit -q -m "chore: release $VERSION"
+git push -u origin "$BRANCH_NAME" --quiet
+gh pr create --title "chore: release $VERSION" \
+  --body "Version bump and changelog for $VERSION. Tag with \`scripts/release.sh --tag $VERSION\` once this merges." \
+  >/dev/null
+ok "opened a release PR from $BRANCH_NAME"
 
 cat <<EOF
 
 Next:
 
-  git push origin main --follow-tags
+  1. Merge the PR once its checks pass.
+  2. git switch main && git pull
+  3. scripts/release.sh --tag $VERSION
 
-Pushing the tag starts the release workflow, which builds every target, generates a CycloneDX
-SBOM, signs the artifacts with GitHub Artifact Attestations, and publishes the Python wheels
-through PyPI Trusted Publishing.
-
-Nothing is signed locally and no credential is needed here: provenance comes from the workflow
-run, which is what makes it verifiable by anyone.
+Tagging starts the release workflow, which builds every target, generates the SBOM, signs the
+artifacts, and creates the GitHub release. Nothing is signed locally: provenance comes from the
+workflow run, which is what makes it verifiable by anyone.
 EOF


### PR DESCRIPTION
Enforcing branch protection for administrators broke the release script: it committed the version
bump straight to `main` and pushed, which is now rejected. The first release attempt would have
failed at the last step.

```bash
scripts/release.sh 0.1.0          # verify, bump, changelog, open a PR
# ... merge once green ...
scripts/release.sh --tag 0.1.0    # tag the merged commit
```

Branch protection does not apply to tags, so phase two pushes directly. It refuses to run unless
`main` is level with the remote *and* already carries the version being tagged, so a
half-finished release cannot be tagged by accident.