### PR TITLE
docs: fix the install instructions and have CI run them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,36 @@ jobs:
           UMBRIK_INTEROP_PLATFORM: linux/amd64
         run: tests/interop/run.sh
 
+  # Runs the README's own install block on a clean runner. Documentation that tells people to
+  # install a distribution flatc, for instance, produces a build failure they cannot diagnose —
+  # this catches that the same day it is written rather than when someone reports it.
+  install-docs:
+    name: README install instructions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Extract the documented steps
+        run: |
+          python3 - <<'PY' > /tmp/install.sh
+          import re
+          text = open("README.md").read()
+          block = re.search(r"<!-- ci:install-linux -->\s*```bash\n(.*?)```", text, re.S)
+          assert block, "README.md has no <!-- ci:install-linux --> bash block"
+          print("set -euxo pipefail")
+          print(block.group(1))
+          PY
+          cat /tmp/install.sh
+
+      - name: Run them exactly as written
+        run: bash /tmp/install.sh
+
+      - name: The result must actually work
+        run: ./target/release/umbrik --version
+
   deny:
     name: Licenses and advisories
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -31,16 +31,32 @@ both directions with DigiDoc4.
 
 ## Install
 
-```bash
-brew install flatbuffers                               # macOS
-apt install flatbuffers-compiler libssl-dev pkg-config  # Debian/Ubuntu
+Debian/Ubuntu:
 
+<!-- ci:install-linux -->
+```bash
+sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
+scripts/install-flatc.sh
 cargo build --release        # binary at target/release/umbrik
 ```
 
-`flatc` must match the `flatbuffers` version pinned in `Cargo.toml`; `scripts/install-flatc.sh`
-fetches the right one. OpenSSL is needed only for the eID directory lookup — build with
-`--no-default-features` for a binary with no network access at all.
+macOS:
+
+```bash
+brew install openssl@3 pkg-config
+scripts/install-flatc.sh
+cargo build --release
+```
+
+**Do not install `flatc` from your distribution.** umbrik generates its FlatBuffers codec at
+build time, and the compiler must match the `flatbuffers` version pinned in `Cargo.toml`; the
+packaged one lags and produces code that will not compile. `scripts/install-flatc.sh` reads the
+required version from `Cargo.toml` and fetches it.
+
+OpenSSL is needed only for the eID directory lookup. `cargo build --release --no-default-features`
+gives a binary that needs neither OpenSSL nor any network access.
+
+The Linux block above is executed verbatim by CI on a clean runner, so these steps cannot rot.
 
 ## Use
 


### PR DESCRIPTION
The README told people to `apt install flatbuffers-compiler`. That package lags the pinned
`flatbuffers` crate and generates code that will not compile — the same 81-error failure the first
CI run hit. Anyone following the README would have reproduced it, with nothing to diagnose it by.

- Corrected to `scripts/install-flatc.sh`, which reads the required version from `Cargo.toml`.
- The Linux block is marked `<!-- ci:install-linux -->` and **executed verbatim by CI** on a clean
  runner, then the resulting binary is run.

Instructions that stop working now fail the build instead of waiting for a bug report.