### PR TITLE
feat: refuse certificates outside their validity window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ Hardware lives in `umbrik-pkcs11`, network in `umbrik-ldap`.
 - **`ErrorCode` discriminants are frozen** across major versions; they cross the C ABI. Add at
   the end, never reorder.
 
+## Certificates
+
+Validity dates are checked and a certificate outside its window is refused unless
+`--allow-expired` is given. Chain and revocation checking are deliberately absent — they need a
+trust store and an OCSP/CRL lookup, and add little where recipients come from an authenticated
+directory or a file the user chose. Do not add a partial version that implies more than it
+delivers.
+
 ## Out of scope
 
 Do not implement without asking: **SC07** (key shares — 2.0 draft, needs an SK relying-party

--- a/README.md
+++ b/README.md
@@ -71,10 +71,21 @@ Omit the password value to be prompted rather than putting it in shell history.
 `-r <isikukood>` looks up the recipient's **authentication** certificate in the Estonian eID
 directory and encrypts to it. No card is needed to encrypt — only to decrypt.
 
-Two caveats. It is a query to a public directory, which discloses the intended recipient to that
-directory's operator; umbrik prints a line to stderr for each lookup rather than doing it
-silently. And umbrik does not validate certificate chains, expiry or revocation — if that is not
-acceptable, fetch the certificate yourself and pass it with `-c`.
+One caveat: it is a query to a public directory, which discloses the intended recipient to that
+directory's operator. umbrik prints a line to stderr for each lookup rather than doing it
+silently.
+
+### What umbrik checks about a certificate
+
+**Validity dates are checked.** A certificate outside its window is refused, because encrypting
+to one usually means encrypting to a card that has been replaced — the container would be
+unopenable. `--allow-expired` overrides it with a warning.
+
+**Chains and revocation are not checked.** Both need infrastructure umbrik deliberately avoids: a
+trust store of eID roots to keep current, and an OCSP or CRL lookup on every encryption. Neither
+adds much where recipients actually come from — `-r` fetches over an authenticated TLS connection
+to the directory that issued the certificate, and `-c` takes a file you chose. If you obtain a
+certificate from an untrusted source, validate it before passing it here.
 
 ### Recipient labels
 

--- a/crates/umbrik-cli/src/main.rs
+++ b/crates/umbrik-cli/src/main.rs
@@ -41,6 +41,12 @@ enum Command {
         /// Pre-shared key recipient (SC05), as `label:base64,<key>`. Repeatable.
         #[arg(long = "secret", value_name = "LABEL:base64,KEY")]
         secrets: Vec<String>,
+        /// Encrypt to a certificate whose validity window has passed, or not yet begun.
+        ///
+        /// Refused by default: an expired certificate usually means the card has been replaced,
+        /// and the container would be one the recipient cannot open.
+        #[arg(long = "allow-expired")]
+        allow_expired: bool,
         /// Recipient X.509 certificate, PEM or DER (SC01 for EC keys, SC02 for RSA). Repeatable.
         #[arg(short = 'c', long = "cert", value_name = "FILE")]
         certs: Vec<PathBuf>,
@@ -217,6 +223,34 @@ fn collect_files(inputs: &[PathBuf]) -> Result<Vec<PayloadFile>> {
     Ok(files)
 }
 
+/// Refuse a certificate outside its validity window unless the caller opted in.
+///
+/// This is a check umbrik can make cheaply and usefully. Chain and revocation checking are
+/// deliberately absent — see the note in `umbrik_core::cert`.
+fn check_validity(
+    parsed: &cert::CertificateRecipient,
+    describe: &str,
+    allow_expired: bool,
+) -> Result<()> {
+    use umbrik_core::cert::Validity;
+
+    let what = match parsed.validity_now() {
+        Validity::Valid | Validity::Unknown => return Ok(()),
+        Validity::Expired => "has expired",
+        Validity::NotYetValid => "is not valid yet",
+    };
+
+    if allow_expired {
+        eprintln!("  warning: the certificate for {describe} {what}");
+        return Ok(());
+    }
+    bail!(
+        "the certificate for {describe} {what}.\n\
+         Encrypting to it would most likely produce a container the recipient cannot open, \
+         because the card has been replaced. Pass --allow-expired to do it anyway."
+    )
+}
+
 /// Parse a certificate from PEM or DER, deciding by content rather than extension.
 fn load_certificate(path: &Path) -> Result<cert::CertificateRecipient> {
     let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
@@ -378,6 +412,7 @@ struct EncryptRequest<'a> {
     password: Option<&'a str>,
     secrets: &'a [String],
     certs: &'a [PathBuf],
+    allow_expired: bool,
     pubkeys: &'a [String],
     #[cfg(feature = "ldap")]
     id_codes: &'a [String],
@@ -392,6 +427,7 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
         password,
         secrets,
         certs,
+        allow_expired,
         pubkeys,
         #[cfg(feature = "ldap")]
         id_codes,
@@ -490,6 +526,7 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
         }
         for found_match in found {
             let parsed = found_match.recipient;
+            check_validity(&parsed, id_code, allow_expired)?;
             let common_name = parsed
                 .common_name
                 .clone()
@@ -524,6 +561,8 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
         // certificates. The `TYPE=ID-card` form is reserved for the directory lookup path,
         // where the card type is actually known from the directory entry rather than guessed
         // from the certificate contents.
+        check_validity(&parsed, &path.display().to_string(), allow_expired)?;
+
         let label = keylabel::certificate(
             parsed.common_name.as_deref(),
             Some(&parsed.sha1),
@@ -588,6 +627,7 @@ fn main() -> Result<()> {
             password,
             secrets,
             certs,
+            allow_expired,
             pubkeys,
             #[cfg(feature = "ldap")]
             recipients,
@@ -599,6 +639,7 @@ fn main() -> Result<()> {
             password: password.as_deref(),
             secrets,
             certs,
+            allow_expired: *allow_expired,
             pubkeys,
             #[cfg(feature = "ldap")]
             id_codes: recipients,

--- a/crates/umbrik-core/src/cert.rs
+++ b/crates/umbrik-core/src/cert.rs
@@ -1,10 +1,21 @@
 //! X.509 certificate parsing, for encrypting to a recipient.
 //!
-//! Only the public key and enough identity to build a key label are extracted. umbrik does not
-//! validate certificate chains, expiry, or revocation: encrypting to a certificate is the
-//! caller's decision about who to trust, and silently accepting an expired certificate is a
-//! different failure from silently rejecting a valid one. Callers that need validation should
-//! do it before handing the certificate here.
+//! # What is and is not checked
+//!
+//! **Validity dates are checked** — see [`CertificateRecipient::validity`]. Encrypting to an
+//! expired certificate usually means encrypting to a card that has been replaced, producing a
+//! container the recipient cannot open. That is worth catching, and costs nothing: the dates are
+//! in the certificate already.
+//!
+//! **Chain and revocation are not.** Both need infrastructure umbrik deliberately does not carry:
+//! a trust store of eID root certificates that would have to be kept current, and an OCSP or CRL
+//! lookup on every encryption. More importantly, neither would add much where recipients
+//! actually come from. A certificate fetched with `-r` arrives over an authenticated TLS
+//! connection to the directory that issued it, and one passed with `-c` is a file the user chose.
+//! The case they would protect — a certificate from an untrusted third party — is better served
+//! by the user validating it themselves than by umbrik implying a guarantee it only partly makes.
+//!
+//! If you need chain validation, do it before calling here.
 
 use x509_cert::der::oid::ObjectIdentifier;
 use x509_cert::der::{Decode, DecodePem, Encode};
@@ -33,6 +44,8 @@ pub struct CertificateRecipient {
     /// `serialNumber` from the subject DN, without its `PNOEE-` prefix, when present. For
     /// Estonian eID certificates this is the isikukood.
     pub id_code: Option<String>,
+    /// The certificate's `notBefore`, as seconds since the Unix epoch.
+    pub not_before: Option<i64>,
     /// The certificate's `notAfter`, as seconds since the Unix epoch.
     ///
     /// Written into eID key labels as `server_exp`, which is how a viewer can show
@@ -94,17 +107,13 @@ fn from_certificate(cert: &Certificate, der: &[u8]) -> Result<CertificateRecipie
     let key = public_key_from_spki(&cert.tbs_certificate.subject_public_key_info)?;
     let subject = cert.tbs_certificate.subject.to_string();
     let sha1 = format!("{:x}", sha1::Sha1::digest(der));
-    let not_after = i64::try_from(
-        cert.tbs_certificate
-            .validity
-            .not_after
-            .to_unix_duration()
-            .as_secs(),
-    )
-    .ok();
+    let to_unix = |t: &x509_cert::time::Time| i64::try_from(t.to_unix_duration().as_secs()).ok();
+    let not_before = to_unix(&cert.tbs_certificate.validity.not_before);
+    let not_after = to_unix(&cert.tbs_certificate.validity.not_after);
 
     Ok(CertificateRecipient {
         can_establish_key: permits_key_establishment(cert),
+        not_before,
         common_name: extract_rdn(&subject, "CN"),
         not_after,
         id_code: extract_id_code(&subject),
@@ -112,6 +121,47 @@ fn from_certificate(cert: &Certificate, der: &[u8]) -> Result<CertificateRecipie
         subject,
         key,
     })
+}
+
+/// Where a certificate sits relative to its validity window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Validity {
+    Valid,
+    /// `notBefore` is in the future.
+    NotYetValid,
+    /// `notAfter` has passed.
+    Expired,
+    /// The certificate carries no usable dates, so nothing can be concluded.
+    Unknown,
+}
+
+impl CertificateRecipient {
+    /// Where this certificate sits relative to `now`, in seconds since the Unix epoch.
+    ///
+    /// Reports rather than decides: whether to refuse an expired certificate is the caller's
+    /// choice. An expired *authentication* certificate does not always mean the key is gone —
+    /// but it usually means the card has been replaced, and the container would be unopenable.
+    pub fn validity(&self, now_unix: i64) -> Validity {
+        match (self.not_before, self.not_after) {
+            (Some(before), _) if now_unix < before => Validity::NotYetValid,
+            (_, Some(after)) if now_unix > after => Validity::Expired,
+            (None, None) => Validity::Unknown,
+            _ => Validity::Valid,
+        }
+    }
+
+    /// Convenience wrapper around [`Self::validity`] using the system clock.
+    ///
+    /// Returns [`Validity::Unknown`] if the clock is before the Unix epoch, rather than
+    /// guessing.
+    pub fn validity_now(&self) -> Validity {
+        match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+            Ok(d) => i64::try_from(d.as_secs())
+                .map(|now| self.validity(now))
+                .unwrap_or(Validity::Unknown),
+            Err(_) => Validity::Unknown,
+        }
+    }
 }
 
 /// OID of the `keyUsage` extension.

--- a/crates/umbrik-core/tests/asymmetric.rs
+++ b/crates/umbrik-core/tests/asymmetric.rs
@@ -284,3 +284,39 @@ fn sc01_key_label_is_not_cryptographically_binding() {
     .expect("label must not affect SC01 decryption");
     assert_eq!(out, files());
 }
+
+// ---------------------------------------------------------------------------
+// Certificate validity
+// ---------------------------------------------------------------------------
+
+/// The committed test certificate is currently valid, which the whole suite depends on.
+#[test]
+fn test_certificate_is_within_its_validity_window() {
+    let parsed = cert::from_pem(&key_pem("cdoc2client-certificate.pem")).unwrap();
+    assert_eq!(parsed.validity_now(), cert::Validity::Valid);
+}
+
+#[test]
+fn reports_a_certificate_that_has_expired() {
+    let parsed = cert::from_pem(&key_pem("cdoc2client-certificate.pem")).unwrap();
+    let after = parsed.not_after.expect("certificate carries notAfter");
+    assert_eq!(parsed.validity(after + 1), cert::Validity::Expired);
+    assert_eq!(parsed.validity(after), cert::Validity::Valid);
+}
+
+#[test]
+fn reports_a_certificate_that_is_not_yet_valid() {
+    let parsed = cert::from_pem(&key_pem("cdoc2client-certificate.pem")).unwrap();
+    let before = parsed.not_before.expect("certificate carries notBefore");
+    assert_eq!(parsed.validity(before - 1), cert::Validity::NotYetValid);
+    assert_eq!(parsed.validity(before), cert::Validity::Valid);
+}
+
+/// Validity reporting must not block parsing: an expired certificate still yields a usable key,
+/// so the caller can decide.
+#[test]
+fn an_expired_certificate_still_parses() {
+    let parsed = cert::from_pem(&key_pem("cdoc2client-certificate.pem")).unwrap();
+    assert!(matches!(parsed.key, PublicKeyRef::Ec(_)));
+    assert!(parsed.not_before.unwrap() < parsed.not_after.unwrap());
+}


### PR DESCRIPTION
umbrik parsed `notAfter` for the key label but never acted on it, so encrypting to a replaced card
produced a container the recipient could not open — silently.

- Validity dates are now checked; a certificate outside its window is refused, with
  `--allow-expired` to override. The check costs nothing, since the dates are already parsed.
- Applies to both `-c` and `-r`.

**Chain and revocation checking stay out**, and the reasoning is now written down rather than
implied. Both need infrastructure umbrik deliberately avoids — a trust store of eID roots to keep
current, an OCSP or CRL lookup on every encryption — and neither adds much where recipients come
from: `-r` fetches over an authenticated TLS connection to the directory that issued the
certificate, and `-c` takes a file the user chose. A partial implementation would imply a
guarantee it does not make.