### PR TITLE
chore: release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,7 @@ Note that a change to the container wire format is breaking even when the API is
 
 - Initial implementation: CDOC2 container format in Rust
 - Python bindings, built for every supported interpreter and signed on publish
-- Refuse certificates outside their validity window (#10) (#10)
-
-### Build and CI
-
-- Fix Scorecard action version and drop unused Dependabot ecosystem
-- Install flatc matching the pinned crate version
-- Pin every action and base image by digest
-- Replace the retired macos-13 runner with macos-15-intel
-- Fix the remaining macos-13 reference in the release matrix
-- Publish a GitHub release with artifacts, checksums and notes
-- Bump the rust-dependencies group across 1 directory with 2 updates (#1) (#1)
-- Attach wheels to the GitHub release, make PyPI opt-in (#7) (#7)
-- Make releases a two-phase pull-request flow (#8) (#8)
+- Refuse certificates outside their validity window (#10)
 
 ### Changed
 
@@ -35,14 +23,15 @@ Note that a change to the container wire format is breaking even when the API is
 ### Dependencies
 
 - Update dependencies to latest compatible versions
+- Bump the rust-dependencies group across 1 directory with 2 updates (#1)
 
 ### Documentation
 
 - Cut prose, keep facts
 - Record the branch protection now in place
 - Branch protection is enforced for administrators
-- Add AGENTS.md with the project's working rules (#6) (#6)
-- Fix the install instructions and have CI run them (#9) (#9)
+- Add AGENTS.md with the project's working rules (#6)
+- Fix the install instructions and have CI run them (#9)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,36 @@ Note that a change to the container wire format is breaking even when the API is
 
 - Initial implementation: CDOC2 container format in Rust
 - Python bindings, built for every supported interpreter and signed on publish
+- Refuse certificates outside their validity window (#10) (#10)
+
+### Build and CI
+
+- Fix Scorecard action version and drop unused Dependabot ecosystem
+- Install flatc matching the pinned crate version
+- Pin every action and base image by digest
+- Replace the retired macos-13 runner with macos-15-intel
+- Fix the remaining macos-13 reference in the release matrix
+- Publish a GitHub release with artifacts, checksums and notes
+- Bump the rust-dependencies group across 1 directory with 2 updates (#1) (#1)
+- Attach wheels to the GitHub release, make PyPI opt-in (#7) (#7)
+- Make releases a two-phase pull-request flow (#8) (#8)
 
 ### Changed
 
 - Ignore Python bytecode caches
+- Versioning policy, release tooling, and a wider build matrix
 
 ### Dependencies
 
 - Update dependencies to latest compatible versions
+
+### Documentation
+
+- Cut prose, keep facts
+- Record the branch protection now in place
+- Branch protection is enforced for administrators
+- Add AGENTS.md with the project's working rules (#6) (#6)
+- Fix the install instructions and have CI run them (#9) (#9)
 
 ### Security
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,8 +25,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
-- {{ commit.message | split(pat="\n") | first | upper_first }}\
-{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}
+- {{ commit.message | split(pat="\n") | first | upper_first }}
 {%- endfor %}
 {% endfor %}
 """
@@ -51,8 +50,12 @@ commit_parsers = [
   { message = "^refactor", group = "Changed" },
   { message = "^docs", group = "Documentation" },
   { message = "^test", group = "Testing" },
-  { message = "^ci|^build", group = "Build and CI" },
-  { message = "^chore\\(deps\\)|^deps", group = "Dependencies" },
+  # Dependency bumps before the build rule, so Dependabot's "build(deps):" lands correctly.
+  { message = "^build\\(deps\\)|^chore\\(deps\\)|^deps", group = "Dependencies" },
+  # Internal CI plumbing is not a user-visible change. It is in the git log for whoever needs
+  # it; a changelog that lists runner-label fixes buries the things people actually read it for.
+  { message = "^ci", skip = true },
+  { message = "^build", group = "Build" },
   { message = "^chore|^style", skip = true },
 
   # Security first: an advisory or a hardening change should never be buried under "Changed".


### PR DESCRIPTION
Version bump and changelog for 0.1.0. Tag with `scripts/release.sh --tag 0.1.0` once this merges.