### PR TITLE
fix: build on Windows, and check every platform on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,37 @@ jobs:
           UMBRIK_INTEROP_PLATFORM: linux/amd64
         run: tests/interop/run.sh
 
+  # Windows and macOS are only otherwise built during a release, so a portability break reaches
+  # a tag before anyone sees it — which is exactly what happened with CK_ULONG, whose width
+  # differs on Win64. Compiling every platform on every PR closes that gap.
+  cross-platform:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+
+      - name: Install flatc
+        shell: bash
+        run: scripts/install-flatc.sh
+        env:
+          FLATC_BIN_DIR: ${{ runner.temp }}/bin
+
+      - name: Put flatc on PATH
+        shell: bash
+        run: echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
+
+      - run: cargo build --all-targets
+      - run: cargo test --release
+      - run: cargo clippy --all-targets -- -D warnings
+
   # Runs the README's own install block on a clean runner. Documentation that tells people to
   # install a distribution flatc, for instance, produces a build failure they cannot diagnose —
   # this catches that the same day it is written rather than when someone reports it.

--- a/crates/umbrik-pkcs11/src/lib.rs
+++ b/crates/umbrik-pkcs11/src/lib.rs
@@ -264,6 +264,12 @@ impl Pkcs11KeyProvider {
         // real card rejects this, that wrapping is the first thing to try.
         let params = Ecdh1DeriveParams::new(EcKdf::null(), peer_point);
 
+        // CK_ULONG is `unsigned long`, which is 64-bit on Unix but **32-bit on Win64**, so
+        // `Ulong` converts from a different primitive per platform. Going through `c_ulong`
+        // rather than a fixed-width integer keeps this compiling everywhere.
+        let value_len = std::os::raw::c_ulong::try_from(secret_len)
+            .map_err(|_| Error::Internal("ECDH secret length does not fit CK_ULONG"))?;
+
         // CARD-SPECIFIC: the derive template.
         //
         // `CKA_VALUE_LEN` is required by some tokens and rejected by others, and a card may
@@ -272,7 +278,7 @@ impl Pkcs11KeyProvider {
         let template = vec![
             Attribute::Class(ObjectClass::SECRET_KEY),
             Attribute::KeyType(KeyType::GENERIC_SECRET),
-            Attribute::ValueLen((secret_len as u64).into()),
+            Attribute::ValueLen(value_len.into()),
             Attribute::Sensitive(false),
             Attribute::Extractable(true),
             Attribute::Token(false),

--- a/scripts/install-flatc.sh
+++ b/scripts/install-flatc.sh
@@ -30,6 +30,29 @@ BIN_DIR="${FLATC_BIN_DIR:-/usr/local/bin}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# Install without assuming a writable prefix or that sudo exists — Windows git-bash has no
+# sudo, and a custom FLATC_BIN_DIR may not exist yet.
+install_flatc() {
+  src="$1"
+  mkdir -p "$BIN_DIR" 2>/dev/null || sudo mkdir -p "$BIN_DIR"
+  dest="$BIN_DIR/$(basename "$src")"
+  if install -m 0755 "$src" "$dest" 2>/dev/null; then
+    :
+  elif command -v sudo >/dev/null 2>&1 && sudo install -m 0755 "$src" "$dest" 2>/dev/null; then
+    :
+  else
+    cp "$src" "$dest"
+    chmod 0755 "$dest" 2>/dev/null || true
+  fi
+  echo "installed $dest"
+  "$dest" --version
+}
+
+# The archive holds flatc.exe on Windows.
+extracted_flatc() {
+  if [ -f "$TMP/flatc.exe" ]; then echo "$TMP/flatc.exe"; else echo "$TMP/flatc"; fi
+}
+
 base="https://github.com/google/flatbuffers/releases/download/v${VERSION}"
 asset=""
 case "$(uname -s)-$(uname -m)" in
@@ -43,8 +66,7 @@ if [ -n "$asset" ]; then
   echo "downloading $asset"
   curl -fsSL "$base/$asset" -o "$TMP/flatc.zip"
   unzip -q "$TMP/flatc.zip" -d "$TMP"
-  install -m 0755 "$TMP/flatc" "$BIN_DIR/flatc" 2>/dev/null \
-    || sudo install -m 0755 "$TMP/flatc" "$BIN_DIR/flatc"
+  install_flatc "$(extracted_flatc)"
 else
   # No official binary for this platform — Linux arm64 in particular. Building takes a few
   # minutes but is the only way to get the exact version.
@@ -55,8 +77,5 @@ else
   cmake -S "$TMP/flatbuffers" -B "$TMP/build" \
     -DCMAKE_BUILD_TYPE=Release -DFLATBUFFERS_BUILD_TESTS=OFF
   cmake --build "$TMP/build" --target flatc -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
-  install -m 0755 "$TMP/build/flatc" "$BIN_DIR/flatc" 2>/dev/null \
-    || sudo install -m 0755 "$TMP/build/flatc" "$BIN_DIR/flatc"
+  install_flatc "$TMP/build/flatc"
 fi
-
-flatc --version


### PR DESCRIPTION
The v0.1.0 release built six of seven targets and failed on Windows.

`CK_ULONG` is `unsigned long` — 64-bit on Unix, **32-bit on Win64** — so cryptoki's `Ulong`
converts from a different primitive per platform, and `(len as u64).into()` does not compile
there. Going through `c_ulong` is portable.

The reason it reached a tag at all is that CI built only Linux: Windows and macOS were compiled
for the first time *during the release*. Both now build, test and lint on every PR, so this class
of break fails before it can reach a release.