### PR TITLE
fix: attach wheels to the release, and stop repeating boilerplate in notes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -128,6 +128,11 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+    env:
+      # This job does not check out the repository, so gh cannot infer which repo it is acting
+      # on and every `gh release` call fails regardless of whether the release exists.
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -138,20 +143,26 @@ jobs:
         with:
           subject-path: "dist/*"
 
-      # release.yml creates the release from the same tag, so wait for it rather than racing.
+      # release.yml creates the release from the same tag. Building seven targets takes around
+      # twelve minutes, so wait well past that rather than racing it.
       - name: Attach to the release
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          for attempt in $(seq 1 30); do
+          for attempt in $(seq 1 60); do
             if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
               gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+
+              # SHA256SUMS is written by release.yml before these wheels exist, so extend it
+              # rather than leaving half the assets uncovered.
+              gh release download "$GITHUB_REF_NAME" -p SHA256SUMS -D sums --clobber
+              (cd dist && sha256sum ./*) | sed 's|\./||' >> sums/SHA256SUMS
+              sort -u -k2 sums/SHA256SUMS -o sums/SHA256SUMS
+              gh release upload "$GITHUB_REF_NAME" sums/SHA256SUMS --clobber
               exit 0
             fi
-            echo "waiting for the release to be created (attempt $attempt)"
-            sleep 20
+            echo "waiting for the release to be created (attempt $attempt of 60)"
+            sleep 30
           done
-          echo "release $GITHUB_REF_NAME was never created" >&2
+          echo "release $GITHUB_REF_NAME was not created within 30 minutes" >&2
           exit 1
 
   # Off until a trusted publisher exists. Set the repository variable PUBLISH_TO_PYPI to 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,11 +187,8 @@ jobs:
           gh attestation verify ./umbrik-x86_64-unknown-linux-gnu --repo livenson/umbrik
           ```
 
-          `SHA256SUMS` covers the same files. `umbrik-sbom.json` is a CycloneDX SBOM of the
+          `SHA256SUMS` covers every asset. `umbrik-sbom.json` is a CycloneDX SBOM of the
           resolved dependency graph.
-
-          Python wheels are published to [PyPI](https://pypi.org/p/umbrik) rather than attached
-          here.
 
           ### Which binary
 
@@ -201,8 +198,7 @@ jobs:
           | `*-unknown-linux-musl` | static, no network features |
           | `*-apple-darwin` | macOS |
           | `*-pc-windows-msvc.exe` | Windows |
-
-          umbrik is unaudited and is not affiliated with RIA or Cybernetica.
+          | `*.whl`, `*.tar.gz` | Python 3.10+, one wheel per platform |
           EOF
 
       - name: Create the GitHub release


### PR DESCRIPTION
### The bug

The attach job never checked out the repository, so `gh` could not infer which repo it was acting
on — every `gh release` call failed regardless of whether the release existed. It polled for ten
minutes and gave up while the release sat there. The v0.1.0 wheels had to be attached by hand.

- `GH_REPO` fixes the cause.
- The window grows to thirty minutes: building seven targets takes around twelve, so the old
  ten-minute limit was under the real time even when the lookup worked.
- `SHA256SUMS` is extended with the wheels instead of covering only the binaries written before
  they existed.

### Release notes

They no longer repeat that umbrik is unaudited and unaffiliated. That does not change per
release, so it is not news — it belongs in the README, `SECURITY.md`, and `umbrik --help`, which
travels with a downloaded binary. Identical boilerplate on every release is what readers learn to
skip, which weakens the message it is trying to send.