### PR TITLE
feat: add -v/--verbose diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ Hardware lives in `umbrik-pkcs11`, network in `umbrik-ldap`.
 - **`ErrorCode` discriminants are frozen** across major versions; they cross the C ABI. Add at
   the end, never reorder.
 
+## Diagnostics
+
+`-v`/`-vv` on the CLI prints to stderr through `Verbosity`, which has no method that accepts a
+secret. Keep it that way: making a leak require a new method is a stronger guarantee than
+remembering not to pass the wrong value. `verbose_output_never_contains_secrets` runs the binary
+at `-vv` and greps its output for the password, key and plaintext.
+
 ## Certificates
 
 Validity dates are checked and a certificate outside its window is refused unless

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ umbrik decrypt -f secrets.cdoc2 --pkcs11 /opt/homebrew/lib/opensc-pkcs11.so -o .
 
 Omit the password value to be prompted rather than putting it in shell history.
 
+### Seeing what happened
+
+`-v` explains what umbrik is doing; `-vv` adds byte counts and offsets:
+
+```
+$ umbrik decrypt -f secrets.cdoc2 --password "my-label:hunter2" -vv -o ./out
+    header 396 bytes, payload 113 bytes (12 nonce + ciphertext + 16 tag)
+  2 recipient(s):
+    #0 SC06       my-label (pw)
+    #1 SC05       backup (secret)
+  trying 2 key candidate(s)
+    limits: ratio 100, entries 1000, bytes 17179869184
+  opened by recipient #0 (SC06) my-label (pw)
+```
+
+Diagnostics go to stderr, so they do not disturb piped output, and they never include key
+material, passwords, PINs or plaintext — everything printed is either already visible to anyone
+holding the container, or local to your machine. Tests assert this by running the binary at `-vv`
+with a distinctive password and searching the output for it.
+
 ### Encrypting to an id code
 
 `-r <isikukood>` looks up the recipient's **authentication** certificate in the Estonian eID

--- a/crates/umbrik-cli/src/main.rs
+++ b/crates/umbrik-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use base64::Engine;
-use clap::{Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand};
 use umbrik_core::cert;
 use umbrik_core::container::{DecryptionKey, Recipient};
 use umbrik_core::keylabel;
@@ -22,8 +22,54 @@ use umbrik_core::Limits;
                   Not affiliated with or endorsed by RIA or Cybernetica. Unaudited."
 )]
 struct Cli {
+    /// Explain what is happening. Repeat for more detail (`-vv`).
+    ///
+    /// Diagnostics go to stderr and never include key material, passwords or PINs — see
+    /// `Verbosity`.
+    #[arg(short, long, global = true, action = ArgAction::Count)]
+    verbose: u8,
+
     #[command(subcommand)]
     command: Command,
+}
+
+/// Diagnostic output.
+///
+/// Everything printed here is derived from what an attacker holding the container can already
+/// see — scheme names, labels, byte lengths — or from the local environment, such as a PKCS#11
+/// slot. Nothing derived from key material passes through it.
+///
+/// The type has no method that takes a secret, which is the point: making a leak require adding
+/// a new method is a stronger guarantee than remembering not to call an existing one. The test
+/// `verbose_output_never_contains_secrets` checks the result.
+#[derive(Clone, Copy)]
+struct Verbosity(u8);
+
+impl Verbosity {
+    /// First level: what umbrik is doing and why.
+    fn say(&self, args: std::fmt::Arguments<'_>) {
+        if self.0 >= 1 {
+            eprintln!("  {args}");
+        }
+    }
+
+    /// Second level: byte offsets, lengths, and other detail useful when something is wrong.
+    fn detail(&self, args: std::fmt::Arguments<'_>) {
+        if self.0 >= 2 {
+            eprintln!("    {args}");
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        self.0 >= 1
+    }
+}
+
+macro_rules! say {
+    ($v:expr, $($arg:tt)*) => { $v.say(format_args!($($arg)*)) };
+}
+macro_rules! detail {
+    ($v:expr, $($arg:tt)*) => { $v.detail(format_args!($($arg)*)) };
 }
 
 #[derive(Subcommand)]
@@ -419,6 +465,7 @@ struct EncryptRequest<'a> {
     #[cfg(feature = "ldap")]
     ldap_test: bool,
     inputs: &'a [PathBuf],
+    v: Verbosity,
 }
 
 fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
@@ -434,6 +481,7 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
         #[cfg(feature = "ldap")]
         ldap_test,
         inputs,
+        v,
     } = req;
     #[cfg(feature = "ldap")]
     let directories = if ldap_test {
@@ -581,6 +629,29 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
     }
 
     let files = collect_files(inputs)?;
+    if v.enabled() {
+        let total: usize = files.iter().map(|f| f.data.len()).sum();
+        say!(
+            v,
+            "{} file(s), {total} bytes before compression",
+            files.len()
+        );
+        for file in &files {
+            detail!(v, "{:<32} {} bytes", file.name, file.data.len());
+        }
+        say!(v, "{} recipient(s):", recipients.len());
+        for recipient in &recipients {
+            // Recipient is non_exhaustive, so an unrecognised kind still gets a line.
+            let described = match recipient {
+                Recipient::Password { label, .. } => format!("SC06  {}", keylabel::display(label)),
+                Recipient::Symmetric { label, .. } => format!("SC05  {}", keylabel::display(label)),
+                Recipient::PublicKey { label, .. } => format!("SC01  {}", keylabel::display(label)),
+                _ => "unknown recipient kind".to_string(),
+            };
+            detail!(v, "{described}");
+        }
+    }
+
     let mut out =
         std::fs::File::create(file).with_context(|| format!("creating {}", file.display()))?;
     let mut rng = rand::rng();
@@ -589,6 +660,11 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("{e}"))
         .with_context(|| format!("encrypting {}", file.display()))?;
 
+    if v.enabled() {
+        if let Ok(meta) = std::fs::metadata(file) {
+            say!(v, "wrote {} bytes", meta.len());
+        }
+    }
     println!("{}", file.display());
     Ok(())
 }
@@ -619,8 +695,39 @@ fn open_provider(
     }
 }
 
+/// Describe a container's structure. Everything here is readable by anyone holding the file.
+fn describe_container(container: &[u8], v: Verbosity) {
+    if !v.enabled() {
+        return;
+    }
+    let Ok(envelope) = umbrik_core::header::Envelope::parse(container) else {
+        say!(v, "container does not parse");
+        return;
+    };
+    detail!(
+        v,
+        "header {} bytes, payload {} bytes (12 nonce + ciphertext + 16 tag)",
+        envelope.header_bytes().len(),
+        envelope.payload().len()
+    );
+    let Ok(header) = envelope.decode_header() else {
+        say!(v, "header does not decode");
+        return;
+    };
+    say!(v, "{} recipient(s):", header.recipients.len());
+    for (i, record) in header.recipients.iter().enumerate() {
+        detail!(
+            v,
+            "#{i} {:<10} {}",
+            record.capsule.scheme(),
+            keylabel::display(&record.key_label)
+        );
+    }
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    let v = Verbosity(cli.verbose);
     match &cli.command {
         Command::Encrypt {
             file,
@@ -646,6 +753,7 @@ fn main() -> Result<()> {
             #[cfg(feature = "ldap")]
             ldap_test: *ldap_test,
             inputs,
+            v,
         }),
 
         Command::Decrypt {
@@ -670,11 +778,33 @@ fn main() -> Result<()> {
             let keys = decryption_keys(password.as_deref(), secret.as_deref(), provider.as_ref())?;
             let container =
                 std::fs::read(file).with_context(|| format!("reading {}", file.display()))?;
+            describe_container(&container, v);
+            let limits = limits.to_limits();
+            if v.enabled() {
+                say!(v, "trying {} key candidate(s)", keys.len());
+                detail!(
+                    v,
+                    "limits: ratio {}, entries {}, bytes {}",
+                    limits.max_compression_ratio,
+                    limits.max_entries,
+                    limits.max_uncompressed_bytes
+                );
+            }
+
             let opened = try_keys(&keys, |key| {
-                umbrik_core::decrypt_to_dir(&container, key, &limits.to_limits(), output)
+                umbrik_core::decrypt_to_dir(&container, key, &limits, output)
             })
             .with_context(|| format!("decrypting {}", file.display()))?;
+
+            say!(
+                v,
+                "opened by recipient #{} ({}) {}",
+                opened.recipient.index,
+                opened.recipient.scheme,
+                keylabel::display(&opened.recipient.label)
+            );
             for entry in &opened.entries {
+                detail!(v, "{:<40} {} bytes", entry.name, entry.size);
                 println!("{}", entry.name);
             }
             Ok(())
@@ -754,6 +884,7 @@ fn main() -> Result<()> {
             let keys = decryption_keys(password.as_deref(), secret.as_deref(), provider.as_ref())?;
             let container =
                 std::fs::read(file).with_context(|| format!("reading {}", file.display()))?;
+            describe_container(&container, v);
             let entries = try_keys(&keys, |key| {
                 umbrik_core::container::list(&container, key, &limits.to_limits())
             })

--- a/crates/umbrik-cli/tests/verbose.rs
+++ b/crates/umbrik-cli/tests/verbose.rs
@@ -9,9 +9,12 @@ use std::process::Command;
 
 const BIN: &str = env!("CARGO_BIN_EXE_umbrik");
 
-/// Distinctive enough that a substring search cannot miss it.
+/// Distinctive enough that a substring search cannot miss them.
 const PASSWORD: &str = "Tr0ubador-SECRET-PASSPHRASE-do-not-log";
 const SECRET_B64: &str = "c3VwZXItc2VjcmV0LTMyLWJ5dGUta2V5LW1hdGVyaWFsIQ==";
+/// What `SECRET_B64` decodes to. Checking only the base64 form would miss a leak of the decoded
+/// bytes, which is the value the library actually holds.
+const SECRET_PLAIN: &str = "super-secret-32-byte-key-material!";
 const PLAINTEXT: &str = "CONFIDENTIAL-PAYLOAD-CONTENTS";
 
 struct Fixture {
@@ -52,11 +55,24 @@ fn run(args: &[&str]) -> String {
 }
 
 fn assert_no_secrets(output: &str, context: &str) {
-    for (what, needle) in [
+    // Every representation a leak could plausibly take: the value as given, the decoded bytes as
+    // text, their hex, and their Debug form. A check for only the base64 input would pass while
+    // the raw key was being printed.
+    let secret_hex: String = SECRET_PLAIN.bytes().map(|b| format!("{b:02x}")).collect();
+    let secret_debug = format!("{:?}", SECRET_PLAIN.as_bytes());
+    let password_debug = format!("{:?}", PASSWORD.as_bytes());
+
+    let forbidden: Vec<(&str, &str)> = vec![
         ("the password", PASSWORD),
-        ("the pre-shared key", SECRET_B64),
+        ("the password as bytes", &password_debug),
+        ("the pre-shared key (base64)", SECRET_B64),
+        ("the pre-shared key (decoded)", SECRET_PLAIN),
+        ("the pre-shared key (hex)", &secret_hex),
+        ("the pre-shared key (bytes)", &secret_debug),
         ("the plaintext", PLAINTEXT),
-    ] {
+    ];
+
+    for (what, needle) in forbidden {
         assert!(
             !output.contains(needle),
             "{context}: {what} appeared in diagnostic output\n--- output ---\n{output}"

--- a/crates/umbrik-cli/tests/verbose.rs
+++ b/crates/umbrik-cli/tests/verbose.rs
@@ -1,0 +1,209 @@
+//! Verbose output must never disclose secret material.
+//!
+//! Diagnostics in a cryptographic tool are a standing hazard: the useful values and the dangerous
+//! ones sit next to each other in the same functions. These tests run the real binary at its
+//! loudest setting and assert that the password, the pre-shared key and the file contents do not
+//! appear anywhere in what it prints.
+
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_umbrik");
+
+/// Distinctive enough that a substring search cannot miss it.
+const PASSWORD: &str = "Tr0ubador-SECRET-PASSPHRASE-do-not-log";
+const SECRET_B64: &str = "c3VwZXItc2VjcmV0LTMyLWJ5dGUta2V5LW1hdGVyaWFsIQ==";
+const PLAINTEXT: &str = "CONFIDENTIAL-PAYLOAD-CONTENTS";
+
+struct Fixture {
+    dir: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("umbrik-verbose-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("secret.txt"), PLAINTEXT).unwrap();
+        Fixture { dir }
+    }
+    fn path(&self, name: &str) -> String {
+        self.dir.join(name).to_string_lossy().into_owned()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Combined stdout and stderr, which is where diagnostics go.
+fn run(args: &[&str]) -> String {
+    let out = Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("running umbrik");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn assert_no_secrets(output: &str, context: &str) {
+    for (what, needle) in [
+        ("the password", PASSWORD),
+        ("the pre-shared key", SECRET_B64),
+        ("the plaintext", PLAINTEXT),
+    ] {
+        assert!(
+            !output.contains(needle),
+            "{context}: {what} appeared in diagnostic output\n--- output ---\n{output}"
+        );
+    }
+}
+
+#[test]
+fn verbose_output_never_contains_secrets() {
+    let fixture = Fixture::new("roundtrip");
+    let container = fixture.path("c.cdoc2");
+
+    for flag in ["-v", "-vv"] {
+        let encrypt = run(&[
+            "encrypt",
+            "-f",
+            &container,
+            "--password",
+            &format!("pw-label:{PASSWORD}"),
+            "--secret",
+            &format!("sk-label:base64,{SECRET_B64}"),
+            flag,
+            &fixture.path("secret.txt"),
+        ]);
+        assert_no_secrets(&encrypt, &format!("encrypt {flag}"));
+
+        let decrypt = run(&[
+            "decrypt",
+            "-f",
+            &container,
+            "--password",
+            &format!("pw-label:{PASSWORD}"),
+            flag,
+            "-o",
+            &fixture.path("out"),
+        ]);
+        assert_no_secrets(&decrypt, &format!("decrypt {flag}"));
+
+        let list = run(&[
+            "list",
+            "-f",
+            &container,
+            "--password",
+            &format!("pw-label:{PASSWORD}"),
+            flag,
+        ]);
+        assert_no_secrets(&list, &format!("list {flag}"));
+    }
+}
+
+/// A failed decryption is the most likely place for a secret to escape, because the error path
+/// has the offending value in hand.
+#[test]
+fn failed_decryption_never_echoes_the_key_material() {
+    let fixture = Fixture::new("failure");
+    let container = fixture.path("c.cdoc2");
+
+    run(&[
+        "encrypt",
+        "-f",
+        &container,
+        "--password",
+        "pw-label:a-different-password",
+        &fixture.path("secret.txt"),
+    ]);
+
+    let output = run(&[
+        "decrypt",
+        "-f",
+        &container,
+        "--password",
+        &format!("pw-label:{PASSWORD}"),
+        "-vv",
+        "-o",
+        &fixture.path("out"),
+    ]);
+    assert_no_secrets(&output, "failed decrypt");
+    assert!(
+        output.to_lowercase().contains("hmac") || output.to_lowercase().contains("verification"),
+        "expected a MAC failure to be reported, got:\n{output}"
+    );
+}
+
+/// Verbosity must be additive: without the flag, output is unchanged.
+#[test]
+fn quiet_by_default() {
+    let fixture = Fixture::new("quiet");
+    let container = fixture.path("c.cdoc2");
+
+    run(&[
+        "encrypt",
+        "-f",
+        &container,
+        "--password",
+        &format!("pw-label:{PASSWORD}"),
+        &fixture.path("secret.txt"),
+    ]);
+    let quiet = run(&[
+        "decrypt",
+        "-f",
+        &container,
+        "--password",
+        &format!("pw-label:{PASSWORD}"),
+        "-o",
+        &fixture.path("out"),
+    ]);
+    assert_eq!(quiet.trim(), "secret.txt");
+}
+
+/// The diagnostics have to be worth printing, or the flag is decoration.
+#[test]
+fn verbose_reports_which_recipient_opened_the_container() {
+    let fixture = Fixture::new("which");
+    let container = fixture.path("c.cdoc2");
+
+    run(&[
+        "encrypt",
+        "-f",
+        &container,
+        "--secret",
+        &format!("sk-label:base64,{SECRET_B64}"),
+        "--password",
+        &format!("pw-label:{PASSWORD}"),
+        &fixture.path("secret.txt"),
+    ]);
+    let output = run(&[
+        "decrypt",
+        "-f",
+        &container,
+        "--secret",
+        &format!("sk-label:base64,{SECRET_B64}"),
+        "-vv",
+        "-o",
+        &fixture.path("out"),
+    ]);
+
+    assert!(
+        output.contains("recipient"),
+        "no recipient summary:\n{output}"
+    );
+    assert!(
+        output.contains("SC05"),
+        "matched scheme not reported:\n{output}"
+    );
+    assert!(
+        output.contains("sk-label"),
+        "matched label not reported:\n{output}"
+    );
+    assert_no_secrets(&output, "verbose decrypt");
+}

--- a/crates/umbrik-core/src/container.rs
+++ b/crates/umbrik-core/src/container.rs
@@ -398,7 +398,7 @@ fn open_header(
     envelope: &Envelope<'_>,
     key: &DecryptionKey,
     limits: &Limits,
-) -> Result<(VerifiedHeader, Fmk)> {
+) -> Result<(VerifiedHeader, Fmk, MatchedRecipient)> {
     let header = envelope.decode_header()?;
 
     if header.recipients.len() as u64 > limits.max_recipients {
@@ -411,7 +411,7 @@ fn open_header(
     let mut saw_candidate = false;
     let mut unsupported: Option<Error> = None;
 
-    for record in &header.recipients {
+    for (index, record) in header.recipients.iter().enumerate() {
         match &record.capsule {
             Capsule::RsaPublicKey { .. }
             | Capsule::KeyServer
@@ -438,7 +438,12 @@ fn open_header(
         let fmk = Fmk::unwrap_xor(&record.encrypted_fmk, &kek)?;
         let hhk = fmk.derive_hhk()?;
         if let Ok(verified) = VerifiedHeader::verify(envelope, header.clone(), &hhk) {
-            return Ok((verified, fmk));
+            let matched = MatchedRecipient {
+                index,
+                label: record.key_label.clone(),
+                scheme: record.capsule.scheme(),
+            };
+            return Ok((verified, fmk, matched));
         }
     }
 
@@ -496,11 +501,29 @@ fn decrypt_payload(
     Ok(Zeroizing::new(plaintext))
 }
 
+/// Which recipient record opened a container.
+///
+/// Useful for diagnostics: a container may list several recipients, and knowing which one the
+/// supplied key matched is the difference between "it worked" and "it worked, and here is why".
+/// Carries no secret material — the label and scheme are already visible to anyone holding the
+/// file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchedRecipient {
+    /// Index into the header's recipient list.
+    pub index: usize,
+    /// The label as stored, which may be a machine-readable `data:` string.
+    pub label: String,
+    /// The scheme tag, e.g. `"SC06"`.
+    pub scheme: &'static str,
+}
+
 /// Everything a successful open produces.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Opened {
     pub entries: Vec<ArchiveEntry>,
+    /// The recipient record whose key material opened the container.
+    pub recipient: MatchedRecipient,
 }
 
 /// Decrypt a container and extract its files into `dest`.
@@ -511,10 +534,10 @@ pub fn decrypt_to_dir(
     dest: &Path,
 ) -> Result<Opened> {
     let envelope = Envelope::parse(container)?;
-    let (verified, fmk) = open_header(&envelope, key, limits)?;
+    let (verified, fmk, recipient) = open_header(&envelope, key, limits)?;
     let compressed = decrypt_payload(&envelope, &verified, &fmk)?;
     let entries = payload::unpack_to_dir(&compressed, dest, limits)?;
-    Ok(Opened { entries })
+    Ok(Opened { entries, recipient })
 }
 
 /// Decrypt a container and return its files in memory.
@@ -543,7 +566,7 @@ pub fn decrypt_to_memory(
 /// List a container's entries without writing files.
 pub fn list(container: &[u8], key: &DecryptionKey, limits: &Limits) -> Result<Vec<ArchiveEntry>> {
     let envelope = Envelope::parse(container)?;
-    let (verified, fmk) = open_header(&envelope, key, limits)?;
+    let (verified, fmk, _) = open_header(&envelope, key, limits)?;
     let compressed = decrypt_payload(&envelope, &verified, &fmk)?;
     payload::list(&compressed, limits)
 }


### PR DESCRIPTION
umbrik was opaque when something went wrong: a failed decryption reported that the MAC did not
verify, and nothing about which recipients the container had or which key was tried.

```
$ umbrik decrypt -f secrets.cdoc2 --password "my-label:hunter2" -vv -o ./out
    header 396 bytes, payload 113 bytes (12 nonce + ciphertext + 16 tag)
  2 recipient(s):
    #0 SC06       my-label (pw)
    #1 SC05       backup (secret)
  trying 2 key candidate(s)
    limits: ratio 100, entries 1000, bytes 17179869184
  opened by recipient #0 (SC06) my-label (pw)
```

Output goes to stderr so piped output is unchanged, and the default is exactly as quiet as before.

### Not logging secrets is a design property, not a discipline

Diagnostics in a cryptographic tool are a standing hazard: the useful values and the dangerous
ones live in the same functions. `Verbosity` has **no method that accepts a secret** — making a
leak require adding a new method is a stronger guarantee than remembering not to pass the wrong
value. Everything printed is either already visible to anyone holding the container (scheme,
label, byte lengths) or local to the machine (PKCS#11 slot).

`crates/umbrik-cli/tests/verbose.rs` runs the real binary at `-vv` with a distinctive password,
pre-shared key and plaintext, and fails if any appears in the output. It covers the **failure**
path too, which is where a secret is most likely to escape, because the error handler has the
offending value in hand.

Also exposes `MatchedRecipient` from `decrypt_to_dir`, so a caller can tell *which* of several
recipients opened a container rather than only that one did.