### PR TITLE
chore: release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 adheres to [Semantic Versioning](https://semver.org/) — see [`VERSIONING.md`](VERSIONING.md).
 Note that a change to the container wire format is breaking even when the API is untouched.
 
+## [0.2.0] - 2026-09-02
+
+
+### Added
+
+- Drop SC02, and complete the RustCrypto 0.11 migration (#15)
+- Add -v/--verbose diagnostics (#16)
+- Explain which directory candidates were rejected, and why (#17)
+
+### Fixed
+
+- Attach wheels to the release, and stop repeating boilerplate in notes (#13)
 ## [0.1.0] - 2026-09-01
 
 
@@ -32,6 +44,10 @@ Note that a change to the container wire format is breaking even when the API is
 - Branch protection is enforced for administrators
 - Add AGENTS.md with the project's working rules (#6)
 - Fix the install instructions and have CI run them (#9)
+
+### Fixed
+
+- Build on Windows, and check every platform on every PR (#12)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,34 @@ Note that a change to the container wire format is breaking even when the API is
 
 ## [0.2.0] - 2026-09-02
 
+### Breaking changes
+
+- Drop SC02, and complete the RustCrypto 0.11 migration (#15)
 
 ### Added
 
-- Drop SC02, and complete the RustCrypto 0.11 migration (#15)
 - Add -v/--verbose diagnostics (#16)
 - Explain which directory candidates were rejected, and why (#17)
 
 ### Fixed
 
 - Attach wheels to the release, and stop repeating boilerplate in notes (#13)
-## [0.1.0] - 2026-09-01
 
+## [0.1.0] - 2026-09-01
 
 ### Added
 
 - Initial implementation: CDOC2 container format in Rust
 - Python bindings, built for every supported interpreter and signed on publish
 - Refuse certificates outside their validity window (#10)
+
+### Fixed
+
+- Build on Windows, and check every platform on every PR (#12)
+
+### Security
+
+- Automate maintenance: Dependabot, CodeQL, Scorecard, signed releases
 
 ### Changed
 
@@ -45,11 +55,4 @@ Note that a change to the container wire format is breaking even when the API is
 - Add AGENTS.md with the project's working rules (#6)
 - Fix the install instructions and have CI run them (#9)
 
-### Fixed
-
-- Build on Windows, and check every platform on every PR (#12)
-
-### Security
-
-- Automate maintenance: Dependabot, CodeQL, Scorecard, signed releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "umbrik-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-ldap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ldap3",
  "umbrik-core",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-pkcs11"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cryptoki",
  "rand",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -20,6 +20,6 @@ crate-type = ["cdylib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-umbrik-core = { path = "../../crates/umbrik-core", version = "0.1.0" }
+umbrik-core = { path = "../../crates/umbrik-core", version = "0.2.0" }
 pyo3.workspace = true
 rand.workspace = true

--- a/cliff.toml
+++ b/cliff.toml
@@ -21,13 +21,14 @@ body = """
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
 ## Unreleased
-{% endif %}
+{% endif -%}
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 - {{ commit.message | split(pat="\n") | first | upper_first }}
 {%- endfor %}
 {% endfor %}
+
 """
 
 footer = """
@@ -43,32 +44,37 @@ split_commits = false
 protect_breaking_commits = true
 
 commit_parsers = [
+  # Breaking changes first, whatever their type. A removal listed under "Added" is worse than
+  # no changelog: the reader takes away the opposite of what happened.
+  { message = "^\\w+(\\([^)]*\\))?!:", group = "<!-- 0 -->Breaking changes" },
+  { body = ".*BREAKING CHANGE", group = "<!-- 0 -->Breaking changes" },
+
   # Conventional Commits.
-  { message = "^feat", group = "Added" },
-  { message = "^fix", group = "Fixed" },
-  { message = "^perf", group = "Changed" },
-  { message = "^refactor", group = "Changed" },
-  { message = "^docs", group = "Documentation" },
-  { message = "^test", group = "Testing" },
+  { message = "^feat", group = "<!-- 1 -->Added" },
+  { message = "^fix", group = "<!-- 2 -->Fixed" },
+  { message = "^perf", group = "<!-- 3 -->Changed" },
+  { message = "^refactor", group = "<!-- 3 -->Changed" },
+  { message = "^docs", group = "<!-- 5 -->Documentation" },
+  { message = "^test", group = "<!-- 6 -->Testing" },
   # Dependency bumps before the build rule, so Dependabot's "build(deps):" lands correctly.
-  { message = "^build\\(deps\\)|^chore\\(deps\\)|^deps", group = "Dependencies" },
+  { message = "^build\\(deps\\)|^chore\\(deps\\)|^deps", group = "<!-- 4 -->Dependencies" },
   # Internal CI plumbing is not a user-visible change. It is in the git log for whoever needs
   # it; a changelog that lists runner-label fixes buries the things people actually read it for.
   { message = "^ci", skip = true },
-  { message = "^build", group = "Build" },
+  { message = "^build", group = "<!-- 7 -->Build" },
   { message = "^chore|^style", skip = true },
 
   # Security first: an advisory or a hardening change should never be buried under "Changed".
-  { message = "(?i)(vulnerab|advisory|CVE-|RUSTSEC|security)", group = "Security" },
+  { message = "(?i)(vulnerab|advisory|CVE-|RUSTSEC|security)", group = "<!-- 2 -->Security" },
 
   # Pre-convention history, classified by what the messages actually say.
-  { message = "(?i)^initial implementation", group = "Added" },
-  { message = "(?i)^(add|adds|added|implement)", group = "Added" },
-  { message = "(?i)^(python bindings|automate maintenance)", group = "Added" },
-  { message = "(?i)^(update|updates|updated|bump) dependencies", group = "Dependencies" },
-  { message = "(?i)^(fix|fixes|fixed|correct)", group = "Fixed" },
-  { message = "(?i)^(ignore|remove|drop)", group = "Changed" },
-  { message = ".*", group = "Changed" },
+  { message = "(?i)^initial implementation", group = "<!-- 1 -->Added" },
+  { message = "(?i)^(add|adds|added|implement)", group = "<!-- 1 -->Added" },
+  { message = "(?i)^(python bindings|automate maintenance)", group = "<!-- 1 -->Added" },
+  { message = "(?i)^(update|updates|updated|bump) dependencies", group = "<!-- 4 -->Dependencies" },
+  { message = "(?i)^(fix|fixes|fixed|correct)", group = "<!-- 2 -->Fixed" },
+  { message = "(?i)^(ignore|remove|drop)", group = "<!-- 3 -->Changed" },
+  { message = ".*", group = "<!-- 3 -->Changed" },
 ]
 
 filter_commits = false

--- a/crates/umbrik-cli/Cargo.toml
+++ b/crates/umbrik-cli/Cargo.toml
@@ -23,9 +23,9 @@ ldap = ["dep:umbrik-ldap"]
 pkcs11 = ["dep:umbrik-pkcs11"]
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.1.0" }
-umbrik-ldap = { path = "../umbrik-ldap", version = "0.1.0", optional = true }
-umbrik-pkcs11 = { path = "../umbrik-pkcs11", version = "0.1.0", optional = true }
+umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
+umbrik-ldap = { path = "../umbrik-ldap", version = "0.2.0", optional = true }
+umbrik-pkcs11 = { path = "../umbrik-pkcs11", version = "0.2.0", optional = true }
 clap.workspace = true
 anyhow.workspace = true
 rpassword.workspace = true

--- a/crates/umbrik-ldap/Cargo.toml
+++ b/crates/umbrik-ldap/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.1.0" }
+umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
 ldap3.workspace = true

--- a/crates/umbrik-pkcs11/Cargo.toml
+++ b/crates/umbrik-pkcs11/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.1.0" }
+umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
 cryptoki.workspace = true
 zeroize.workspace = true
 


### PR DESCRIPTION
Version bump and changelog for 0.2.0. Tag with `scripts/release.sh --tag 0.2.0` once this merges.