### PR TITLE
ci: stop dependency review reporting our own crates as unlicensed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,10 @@ jobs:
           allow-licenses: >-
             MIT, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-2-Clause,
             BSD-3-Clause, ISC, Unicode-3.0, Zlib, 0BSD, Unlicense
+          # Our own workspace crates. They carry license.workspace = true, so cargo reads them as
+          # MIT, but this action does not: it sees the `version` field on a path dependency, looks
+          # the name up on crates.io, finds nothing there because we do not publish, and reports
+          # "Unknown License". Exempting them silences that on every pull request. Remove these
+          # entries if umbrik is ever published to crates.io, at which point the lookup resolves.
+          allow-dependencies-licenses: >-
+            pkg:cargo/umbrik-core, pkg:cargo/umbrik-ldap, pkg:cargo/umbrik-pkcs11


### PR DESCRIPTION
`umbrik-core`, `umbrik-ldap` and `umbrik-pkcs11` show up as **Unknown License** in the dependency review comment on every PR that touches a manifest.

They are MIT. Each inherits `license.workspace = true`, and `cargo metadata` confirms it:

```
umbrik-core    0.2.0  license='MIT'
umbrik-ldap    0.2.0  license='MIT'
umbrik-pkcs11  0.2.0  license='MIT'
```

The action never reads those manifests. Internal dependencies are declared as `{ path = "../umbrik-core", version = "0.2.0" }` — the `version` field is required to publish — so the action treats them as registry crates, looks them up on crates.io, and gets a 404 because umbrik is not published there. No registry entry, no license metadata.

Exempting the three by purl is the fix that does not require publishing. `cargo deny check licenses` covers the real third-party graph and is untouched.