### PR TITLE
ci: build a Windows wheel, and stop dismissing CodeQL by hand

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,37 @@
+name: umbrik CodeQL configuration
+
+# security-extended over the default suite: it adds the cryptography and untrusted-input queries,
+# which is the half of CodeQL that matches umbrik's attack surface. Container bytes are parsed
+# before anything is authenticated.
+queries:
+  - uses: security-extended
+
+query-filters:
+  # rust/hard-coded-cryptographic-value fires on every constant in the crate and has been wrong
+  # all eighteen times: sixteen test vectors, and the two HKDF info strings in container.rs.
+  #
+  # It cannot be otherwise here. The query looks for a key or salt an attacker could read out of
+  # the binary, but CDOC2's salts and info strings -- "CDOC20salt", "CDOC20cek", "CDOC20hmac",
+  # "CDOC20payload" -- are published wire-format constants. Every implementation hard-codes the
+  # same bytes; that is what makes containers interoperable. A value read from configuration
+  # instead would be a bug. The test vectors are hard-coded for the same reason: a vector that
+  # was generated rather than fixed would prove nothing.
+  #
+  # Dismissing each alert by hand does not scale -- a new vector means a new alert -- and it
+  # trains us to click "false positive" on this rule without reading it, which is worse than
+  # excluding it deliberately.
+  #
+  # What covers this instead, and covers it better:
+  #   - docs/CRYPTO-CONSTANTS.md cites every constant to the specification and to
+  #     open-eid/cdoc2-java-ref-impl, and AGENTS.md forbids adding one without a citation.
+  #   - tests/interop/run.sh round trips against the reference cdoc2-cli in both directions,
+  #     which is the only thing that catches a wrong constant. A self-consistent wrong value
+  #     passes every unit test in both directions; it fails interop immediately.
+  #   - A fixed-RNG golden file pins the exact output bytes, so a constant cannot change
+  #     unnoticed.
+  #
+  # Revisit if umbrik ever gains a genuine secret in source -- a default password, an API key.
+  # Nothing of that kind exists today, and the review checklist for a new constant is the
+  # citation requirement above.
+  - exclude:
+      id: rust/hard-coded-cryptographic-value

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: rust
-          queries: security-extended
+          # Query selection and the one documented exclusion live here, with the reasoning.
+          config-file: .github/codeql/config.yml
 
       - uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   wheels:
-    name: Wheel ${{ matrix.target }}
+    name: Wheel ${{ matrix.os }} ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,15 +29,27 @@ jobs:
           - { os: ubuntu-24.04-arm, target: aarch64, manylinux: auto }
           - { os: macos-latest,     target: aarch64, manylinux: "off" }
           - { os: macos-15-intel,   target: x86_64,  manylinux: "off" }
+          - { os: windows-latest,   target: x86_64,  manylinux: "off" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
-      - name: Install flatc (macOS)
-        if: runner.os == 'macOS'
-        run: brew install flatbuffers
+      # Linux builds inside the manylinux container and installs flatc there instead, via
+      # before-script-linux below. macOS and Windows build on the runner itself.
+      #
+      # scripts/install-flatc.sh rather than brew or choco: it reads the version from Cargo.toml,
+      # so it cannot drift from the `flatbuffers` crate. A mismatch generates code that does not
+      # compile, and a distribution package is whatever version it happens to be that week.
+      - name: Install flatc
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          scripts/install-flatc.sh
+          echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
+        env:
+          FLATC_BIN_DIR: ${{ runner.temp }}/bin
 
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
@@ -68,10 +80,15 @@ jobs:
           if-no-files-found: error
 
   # The point of abi3: one wheel, every supported interpreter. Verified, not assumed.
+  #
+  # Linux carries the full interpreter sweep. Windows runs one version, because what is in doubt
+  # there is the platform rather than the ABI — umbrik-python is not a default workspace member,
+  # so a plain `cargo build` on the Windows CI job never compiles it, and this is the only thing
+  # that exercises the binding on Windows at all.
   test:
-    name: Test wheel on Python ${{ matrix.python }}
+    name: Test wheel on ${{ matrix.os }} Python ${{ matrix.python }}
     needs: wheels
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -80,6 +97,9 @@ jobs:
         # Every CPython still receiving upstream support. 3.9 reached end of life in
         # October 2025 and is deliberately excluded.
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest]
+        include:
+          - { os: windows-latest, python: "3.10" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -88,10 +108,12 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wheel-ubuntu-latest-x86_64
+          name: wheel-${{ matrix.os }}-x86_64
           path: dist
 
       - name: Install the wheel and run the tests
+        # bash on the Windows runner too: PowerShell does not expand the wheel glob.
+        shell: bash
         run: |
           python -m pip install --upgrade pip pytest
           # The same cp310-abi3 wheel is installed on every version in the matrix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ and byte range is published. If you cannot find a value in the specification or 
 your way to a plausible value.
 
 All constants are recorded with citations in [`docs/CRYPTO-CONSTANTS.md`](docs/CRYPTO-CONSTANTS.md).
-Add to it rather than scattering literals through the code.
+Add to it rather than scattering literals through the code. That citation, not CodeQL, is what
+guards this: `rust/hard-coded-cryptographic-value` is excluded in
+[`.github/codeql/config.yml`](.github/codeql/config.yml), which explains why it cannot be right
+about published wire constants.
 
 Four that look wrong but are not:
 


### PR DESCRIPTION
### Windows wheel

We ship `umbrik-x86_64-pc-windows-msvc.exe` and fixed a Win64 `CK_ULONG` bug for it in #12, but the wheel matrix had no Windows entry, so `pip install umbrik` finds nothing there.

Worth noting the binding has **never been compiled on Windows**: `umbrik-python` is not a default workspace member, so the Windows CI job's `cargo build --all-targets` skips it. This job is the first thing that builds it, and I could not verify it locally on macOS — CI is the test.

The wheel is also installed and exercised, not just built. One interpreter there: abi3 coverage is what the Linux 3.10–3.14 sweep proves, and what is in doubt on Windows is the platform.

### flatc on macOS

The wheel job used `brew install flatbuffers`. `AGENTS.md` says to use `scripts/install-flatc.sh`, which reads the version from `Cargo.toml` and so cannot drift from the `flatbuffers` crate. Brew matches today (25.12.19) by luck; a mismatch generates code that does not compile.

### CodeQL

`rust/hard-coded-cryptographic-value` has produced 18 alerts and been wrong 18 times — 16 test vectors, 2 HKDF info strings. It cannot be right here: `"CDOC20salt"`, `"CDOC20cek"`, `"CDOC20hmac"` are published wire-format constants that every CDOC2 implementation hard-codes. Reading them from configuration would be the bug.

Dismissing each by hand does not scale and trains us to click "false positive" on the rule without reading it. It is now excluded in `.github/codeql/config.yml`, which documents what covers this instead: cited constants in `docs/CRYPTO-CONSTANTS.md`, the interop gate, and the golden file. Every other `security-extended` query is unchanged.