### PR TITLE
fix: strip terminal escapes from untrusted text, and close a release race

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -150,6 +150,8 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # To watch release.yml's run.
+      actions: read
     env:
       # This job does not check out the repository, so gh cannot infer which repo it is acting
       # on and every `gh release` call fails regardless of whether the release exists.
@@ -165,27 +167,36 @@ jobs:
         with:
           subject-path: "dist/*"
 
-      # release.yml creates the release from the same tag. Building seven targets takes around
-      # twelve minutes, so wait well past that rather than racing it.
-      - name: Attach to the release
+      # release.yml creates the release from the same tag, then uploads the binaries and
+      # SHA256SUMS. Waiting for the release to *exist* is not enough: it exists a few seconds
+      # before SHA256SUMS does, and a poll landing in that window fails the download below.
+      # Waiting for that workflow's run to finish removes any reasoning about upload order.
+      # Seven targets take around twelve minutes; allow well past that.
+      - name: Wait for the release workflow
         run: |
           for attempt in $(seq 1 60); do
-            if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-              gh release upload "$GITHUB_REF_NAME" dist/* --clobber
-
-              # SHA256SUMS is written by release.yml before these wheels exist, so extend it
-              # rather than leaving half the assets uncovered.
-              gh release download "$GITHUB_REF_NAME" -p SHA256SUMS -D sums --clobber
-              (cd dist && sha256sum ./*) | sed 's|\./||' >> sums/SHA256SUMS
-              sort -u -k2 sums/SHA256SUMS -o sums/SHA256SUMS
-              gh release upload "$GITHUB_REF_NAME" sums/SHA256SUMS --clobber
-              exit 0
-            fi
-            echo "waiting for the release to be created (attempt $attempt of 60)"
+            state=$(gh run list --workflow release.yml --branch "$GITHUB_REF_NAME" --event push \
+                      --json status,conclusion --jq '.[0] | "\(.status)/\(.conclusion)"')
+            case "$state" in
+              completed/success) exit 0 ;;
+              completed/*) echo "release workflow finished with $state" >&2; exit 1 ;;
+            esac
+            echo "release workflow is ${state:-not started} (attempt $attempt of 60)"
             sleep 30
           done
-          echo "release $GITHUB_REF_NAME was not created within 30 minutes" >&2
+          echo "release workflow did not finish within 30 minutes" >&2
           exit 1
+
+      - name: Attach to the release
+        run: |
+          gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+
+          # SHA256SUMS was written by release.yml before these wheels existed, so extend it
+          # rather than leaving half the assets uncovered.
+          gh release download "$GITHUB_REF_NAME" -p SHA256SUMS -D sums --clobber
+          (cd dist && sha256sum ./*) | sed 's|\./||' >> sums/SHA256SUMS
+          sort -u -k2 sums/SHA256SUMS -o sums/SHA256SUMS
+          gh release upload "$GITHUB_REF_NAME" sums/SHA256SUMS --clobber
 
   # Off until a trusted publisher exists. Set the repository variable PUBLISH_TO_PYPI to 'true'
   # to enable it; nothing else needs to change.

--- a/crates/umbrik-cli/src/main.rs
+++ b/crates/umbrik-cli/src/main.rs
@@ -72,6 +72,25 @@ macro_rules! detail {
     ($v:expr, $($arg:tt)*) => { $v.detail(format_args!($($arg)*)) };
 }
 
+/// Text chosen by someone other than the person reading it, made safe for their terminal.
+///
+/// Key labels, archive entry names and directory entries are written by whoever produced the
+/// container or the directory record, and printed on the screen of whoever opens it. A control
+/// character in one of them is a terminal escape: a label that rewrites the window title, or
+/// an entry name that clears the line and prints a different one in its place. Every such
+/// string goes through here on its way out; nothing in this file prints one directly. The test
+/// `untrusted_text_is_printed_without_control_characters` checks the result.
+fn printable(text: &str) -> String {
+    text.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
+/// `keylabel::display` for a terminal. The only way this file renders a label.
+fn show_label(label: &str) -> String {
+    printable(&keylabel::display(label))
+}
+
 #[derive(Subcommand)]
 enum Command {
     /// Encrypt files into a container.
@@ -575,7 +594,7 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
                     .find(|part| part.trim_start().starts_with("o="))
                     .unwrap_or("?")
                     .trim();
-                detail!(v, "{credential}: {}", rejected.reason.reason());
+                detail!(v, "{}: {}", printable(credential), rejected.reason.reason());
             }
         }
 
@@ -645,7 +664,7 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
             Some(&parsed.sha1),
             file_name.as_deref(),
         );
-        eprintln!("  recipient: {}", keylabel::display(&label));
+        eprintln!("  recipient: {}", show_label(&label));
 
         recipients.push(Recipient::PublicKey {
             label,
@@ -666,15 +685,15 @@ fn run_encrypt(req: EncryptRequest<'_>) -> Result<()> {
             files.len()
         );
         for file in &files {
-            detail!(v, "{:<32} {} bytes", file.name, file.data.len());
+            detail!(v, "{:<32} {} bytes", printable(&file.name), file.data.len());
         }
         say!(v, "{} recipient(s):", recipients.len());
         for recipient in &recipients {
             // Recipient is non_exhaustive, so an unrecognised kind still gets a line.
             let described = match recipient {
-                Recipient::Password { label, .. } => format!("SC06  {}", keylabel::display(label)),
-                Recipient::Symmetric { label, .. } => format!("SC05  {}", keylabel::display(label)),
-                Recipient::PublicKey { label, .. } => format!("SC01  {}", keylabel::display(label)),
+                Recipient::Password { label, .. } => format!("SC06  {}", show_label(label)),
+                Recipient::Symmetric { label, .. } => format!("SC05  {}", show_label(label)),
+                Recipient::PublicKey { label, .. } => format!("SC01  {}", show_label(label)),
                 _ => "unknown recipient kind".to_string(),
             };
             detail!(v, "{described}");
@@ -749,7 +768,7 @@ fn describe_container(container: &[u8], v: Verbosity) {
             v,
             "#{i} {:<10} {}",
             record.capsule.scheme(),
-            keylabel::display(&record.key_label)
+            show_label(&record.key_label)
         );
     }
 }
@@ -830,11 +849,12 @@ fn main() -> Result<()> {
                 "opened by recipient #{} ({}) {}",
                 opened.recipient.index,
                 opened.recipient.scheme,
-                keylabel::display(&opened.recipient.label)
+                show_label(&opened.recipient.label)
             );
             for entry in &opened.entries {
-                detail!(v, "{:<40} {} bytes", entry.name, entry.size);
-                println!("{}", entry.name);
+                let name = printable(&entry.name);
+                detail!(v, "{name:<40} {} bytes", entry.size);
+                println!("{name}");
             }
             Ok(())
         }
@@ -886,7 +906,7 @@ fn main() -> Result<()> {
                 println!(
                     "{}\t{}",
                     recipient.capsule.scheme(),
-                    keylabel::display(&recipient.key_label)
+                    show_label(&recipient.key_label)
                 );
             }
             Ok(())
@@ -919,7 +939,7 @@ fn main() -> Result<()> {
             })
             .with_context(|| format!("reading {}", file.display()))?;
             for entry in &entries {
-                println!("{}\t{}", entry.size, entry.name);
+                println!("{}\t{}", entry.size, printable(&entry.name));
             }
             Ok(())
         }

--- a/crates/umbrik-cli/tests/verbose.rs
+++ b/crates/umbrik-cli/tests/verbose.rs
@@ -223,3 +223,71 @@ fn verbose_reports_which_recipient_opened_the_container() {
     );
     assert_no_secrets(&output, "verbose decrypt");
 }
+
+/// Labels and entry names are chosen by whoever made the container, and printed on the terminal
+/// of whoever opens it. A control character in either is a terminal escape waiting for a
+/// victim: this label rewrites the window title, the entry name erases the line it is on.
+#[test]
+fn untrusted_text_is_printed_without_control_characters() {
+    let fixture = Fixture::new("escapes");
+    let container = fixture.path("c.cdoc2");
+    let label = "innocent\x1b]0;pwned\x07label";
+    let password = format!("{label}:{PASSWORD}");
+
+    // NTFS refuses control characters in file names, so this half runs only where a file can
+    // carry one.
+    #[cfg(unix)]
+    let hostile_file = {
+        let name = "report\x1b[2K\rmalware.pdf";
+        std::fs::write(fixture.dir.join(name), b"x").unwrap();
+        Some(fixture.path(name))
+    };
+    #[cfg(not(unix))]
+    let hostile_file: Option<String> = None;
+    let inputs: Vec<String> = std::iter::once(fixture.path("secret.txt"))
+        .chain(hostile_file)
+        .collect();
+
+    let mut args = vec!["encrypt", "-f", &container, "--password", &password, "-vv"];
+    args.extend(inputs.iter().map(String::as_str));
+    let encrypt = run(&args);
+
+    let out = fixture.path("out");
+    let outputs = [
+        ("encrypt -vv", encrypt),
+        ("recipients", run(&["recipients", "-f", &container])),
+        (
+            "list -vv",
+            run(&["list", "-f", &container, "--password", &password, "-vv"]),
+        ),
+        (
+            "decrypt -vv",
+            run(&[
+                "decrypt",
+                "-f",
+                &container,
+                "--password",
+                &password,
+                "-vv",
+                "-o",
+                &out,
+            ]),
+        ),
+    ];
+    for (context, output) in outputs {
+        // Newlines and the tab that separates columns are the only control characters the CLI
+        // has any business emitting.
+        let escaped: Vec<char> = output
+            .chars()
+            .filter(|c| c.is_control() && !matches!(c, '\n' | '\t'))
+            .collect();
+        assert!(
+            escaped.is_empty(),
+            "{context}: control characters {escaped:?} reached the terminal\n--- output ---\n{output}"
+        );
+        assert!(
+            output.contains("innocent"),
+            "{context}: the label was dropped rather than sanitised\n--- output ---\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
Two follow-ups from the security review of `v0.1.0..main`. Neither is a vulnerability; both remove a question.

### Terminal escapes in untrusted text

Key labels and archive entry names are chosen by whoever made the container; directory `o=` entries by whoever runs the directory. All were printed verbatim to the terminal of whoever opens the container. A label like `innocent\x1b]0;pwned\x07` rewrites the window title; an entry name with `\x1b[2K\r` erases the line it is on and prints another in its place.

Control characters are now replaced with U+FFFD at the one place such text leaves the CLI. `main.rs` no longer calls `keylabel::display` directly — `show_label` wraps it — so a new print site cannot forget. Same pattern as `Verbosity`: make the mistake require a new function.

`untrusted_text_is_printed_without_control_characters` encrypts with a hostile label and (on Unix, where a file name can carry one) a hostile file name, then checks `encrypt -vv`, `recipients`, `list -vv` and `decrypt -vv` emit nothing but newlines and tabs.

### Release race

`release.yml` creates the release, then uploads `SHA256SUMS`. `python.yml` polled for the release to *exist*, which it does a few seconds before the checksum file — a poll landing in that gap fails the download and the wheels never attach. It now waits for the `release.yml` run to conclude, which needs `actions: read` and removes any dependence on upload order. Verified that `gh run list --branch v0.2.0` resolves tag runs.