### PR TITLE
chore: release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 adheres to [Semantic Versioning](https://semver.org/) — see [`VERSIONING.md`](VERSIONING.md).
 Note that a change to the container wire format is breaking even when the API is untouched.
 
+## [0.2.1] - 2026-09-02
+
+### Fixed
+
+- Strip terminal escapes from labels, entry names and directory records (#21)
+
 ## [0.2.0] - 2026-09-02
 
 ### Breaking changes
 
 - Drop SC02, and complete the RustCrypto 0.11 migration (#15)
+- Release 0.2.0 (#18)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "umbrik-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-ldap"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ldap3",
  "umbrik-core",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-pkcs11"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cryptoki",
  "rand",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "umbrik-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -20,6 +20,6 @@ crate-type = ["cdylib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-umbrik-core = { path = "../../crates/umbrik-core", version = "0.2.0" }
+umbrik-core = { path = "../../crates/umbrik-core", version = "0.2.1" }
 pyo3.workspace = true
 rand.workspace = true

--- a/crates/umbrik-cli/Cargo.toml
+++ b/crates/umbrik-cli/Cargo.toml
@@ -23,9 +23,9 @@ ldap = ["dep:umbrik-ldap"]
 pkcs11 = ["dep:umbrik-pkcs11"]
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
-umbrik-ldap = { path = "../umbrik-ldap", version = "0.2.0", optional = true }
-umbrik-pkcs11 = { path = "../umbrik-pkcs11", version = "0.2.0", optional = true }
+umbrik-core = { path = "../umbrik-core", version = "0.2.1" }
+umbrik-ldap = { path = "../umbrik-ldap", version = "0.2.1", optional = true }
+umbrik-pkcs11 = { path = "../umbrik-pkcs11", version = "0.2.1", optional = true }
 clap.workspace = true
 anyhow.workspace = true
 rpassword.workspace = true

--- a/crates/umbrik-ldap/Cargo.toml
+++ b/crates/umbrik-ldap/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
+umbrik-core = { path = "../umbrik-core", version = "0.2.1" }
 ldap3.workspace = true

--- a/crates/umbrik-pkcs11/Cargo.toml
+++ b/crates/umbrik-pkcs11/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-umbrik-core = { path = "../umbrik-core", version = "0.2.0" }
+umbrik-core = { path = "../umbrik-core", version = "0.2.1" }
 cryptoki.workspace = true
 zeroize.workspace = true
 


### PR DESCRIPTION
Version bump and changelog for 0.2.1. Tag with `scripts/release.sh --tag 0.2.1` once this merges.